### PR TITLE
Fix to properly get user id in version 9

### DIFF
--- a/scripts/init.js
+++ b/scripts/init.js
@@ -4,7 +4,7 @@ Hooks.once("ready", () => {
     console.log('PF2e Exploration Activities | Hooked in');
     game.socket.on('module.pf2e-exploration-activities', (data) => {
         if (data.operation === 'playerExplorationActivity') {
-            if (data.actor.permission[game.user._id] >= 3) {
+            if (data.actor.permission[game.user.data._id] >= 3) {
                 explorationActivity(data.actor);
             }
         }


### PR DESCRIPTION
After updating to version 9, I noticed that this module no longer worked. After some investigation, it appears that user._id was moved to be user.data._id - this is a simple change to fix that